### PR TITLE
add tryThis and tryThisAsync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "try-nice",
   "description": "try/catch wrapper",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "license": "MIT",
   "author": "An Duong <an.duongx@gmail.com>",
   "homepage": "https://github.com/anduong96/try-nice",
@@ -17,7 +17,8 @@
     "email": "an.duongx@gmail.com"
   },
   "contributors": [
-    "An Duong <an.duongx@gmail.com> ()"
+    "An Duong <an.duongx@gmail.com> ()",
+    "Adam Stover <nehtaro@gmail.com> ()"
   ],
   "scripts": {
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export function tryNice<
   F extends (...arg: Array<Argument<F>>) => V | undefined = any
 >(fn: F, ...args: Array<Argument<F>>): [V?, E?] {
   try {
-    return [fn.apply(null, args)]
+    return [Reflect.apply(fn, null, args)]
   } catch (error) {
     return [undefined, error as E]
   }
@@ -40,7 +40,61 @@ export async function tryNiceAsync<
   F extends (...arg: Array<Argument<F>>) => V | undefined = any
 >(fn: F, ...args: Array<Argument<F>>): Promise<[V?, E?]> {
   try {
-    return [await fn.apply(null, args)]
+    return [Reflect.apply(fn, null, args)]
+  } catch (error) {
+    return [undefined, error as E]
+  }
+}
+
+
+/**
+ * Clean try/catch wrapper with 'this' as an argument
+ *
+ * @export
+ * @template V Return value
+ * @template E Error
+ * @template T This
+ * @template F Function
+ * @param {F} fn
+ * @param {T} thisArg
+ * @param {...Array<Argument<F>>} args
+ * @returns {[V?, E?]}
+ */
+export function tryThis<
+  V = any,
+  E = Error,
+  F extends (...arg: Array<Argument<F>>) => V | undefined = any,
+  T = any
+>(fn: F, thisArg: T, ...args: Array<Argument<F>>): [V?, E?] {
+  try {
+    return [Reflect.apply(fn, thisArg, args)]
+  } catch (error) {
+    return [undefined, error as E]
+  }
+}
+
+
+/**
+ * Clean async try/catch wrapper with 'this' as an argument
+ *
+ * @export
+ * @template V Return value
+ * @template E Error
+ * @template T This
+ * @template F Function
+ * @param {F} fn
+ * @param {T} thisArg
+ * @param {...Array<Argument<F>>} args
+ * @returns {Promise<[V?, E?]>}
+ */
+export async function tryThisAsync<
+  V = any,
+  E = Error,
+  F extends (...arg: Array<Argument<F>>) => V | undefined = any,
+  T = any
+>(fn: F, thisArg: T, ...args: Array<Argument<F>>): Promise<[V?, E?]> {
+  try {
+    return [await Reflect.apply(fn, thisArg, args)]
   } catch (error) {
     return [undefined, error as E]
   }


### PR DESCRIPTION
There is no clean way to add a 'this' arg without introducing breaking changes to tryNice and tryNiceAsync. Having an option to use a 'this' arg would be helpful when working with class methods which might throw, so here are two new export functions.

This PR also changes fn.apply to Reflect.apply. This solves the rare edge case of a function's 'apply' method being overwritten. This could also be solved with Function.prototype.apply.call, but I chose Reflect because calling Reflect.apply on a non-function throws an error, while Function.prototype.apply does not.